### PR TITLE
fix: ограничить автослияние ветками из репозитория

### DIFF
--- a/.github/workflows/automerge-codex.yml
+++ b/.github/workflows/automerge-codex.yml
@@ -1,0 +1,50 @@
+name: Automerge Codex
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: >-
+      contains(join(github.event.pull_request.labels.*.name, ','), 'automerge') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Автослияние PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.state !== 'open') {
+              core.info(`PR #${prNumber} уже закрыт, пропускаем.`);
+              return;
+            }
+
+            if (pr.draft) {
+              core.info(`PR #${prNumber} в статусе draft, пропускаем.`);
+              return;
+            }
+
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              merge_method: 'squash',
+            });
+            core.info(`PR #${prNumber} успешно слит.`);


### PR DESCRIPTION
## Резюме
- добавлен workflow `automerge-codex` с автослиянием помеченных PR
- условие запуска дополнено проверкой `github.event.pull_request.head.repo.full_name == github.repository`, чтобы запускаться только для веток внутри репозитория

## Влияние на производительность и сеть
- изменений нет

## Модули
- `.github/workflows/automerge-codex.yml`

## Обработка ошибок и ретраи
- не применимо

------
https://chatgpt.com/codex/tasks/task_e_68d91dc381e083308c0e6b697505e42e