### PR TITLE
ci: добавить workflow telegram-постинга

### DIFF
--- a/.github/workflows/telegram-post.yml
+++ b/.github/workflows/telegram-post.yml
@@ -1,0 +1,38 @@
+name: Telegram Post Scheduler
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      DEEPSEEK_APPI: ${{ secrets.DEEPSEEK_APPI }}
+      USERNAMETELERGRAMBOT: ${{ secrets.USERNAMETELERGRAMBOT }}
+      TELEGRAMKEY: ${{ secrets.TELEGRAMKEY }}
+      TELEGRAMKANAL: ${{ secrets.TELEGRAMKANAL }}
+      TGUSERID: ${{ secrets.TGUSERID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Black (check)
+        run: black --check .
+
+      - name: Ruff
+        run: ruff .
+
+      - name: Run telegram post once
+        run: python -m src.telegram_post.main poll-once


### PR DESCRIPTION
## Цель изменения
- настроить расписанный и ручной запуск telegram-постинга через GitHub Actions

## Влияние на производительность и сеть
- запуск по cron каждые 5 минут; дополнительных внешних запросов в рамках workflow нет, кроме шагов установки зависимостей

## Затронутые модули
- .github/workflows/telegram-post.yml

## Логика ретраев и обработка ошибок
- используется стандартное поведение команд black, ruff и python; дополнительные ретраи не добавлены

------
https://chatgpt.com/codex/tasks/task_e_68d91bed46c4833084daa1e5a5ded679