### PR TITLE
chore: обновить ограничение httpx для telegram-бота

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httpx==0.27.0
+httpx~=0.25.2
 tenacity==8.2.3
 typer==0.9.0
 python-telegram-bot==20.7


### PR DESCRIPTION
## Summary
- обновил ограничение зависимости httpx до совместимой версии с python-telegram-bot 20.7

## Testing
- python -m pip install -r requirements.txt
- black --check .
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d923825ae48330b9bd1a53e2a1b10a