### PR TITLE
Обновить автомёрдж для запуска при создании PR

### DIFF
--- a/.github/workflows/automerge-codex.yml
+++ b/.github/workflows/automerge-codex.yml
@@ -3,6 +3,7 @@ name: Automerge Codex
 on:
   pull_request:
     types:
+      - opened
       - labeled
       - synchronize
       - reopened
@@ -14,9 +15,7 @@ permissions:
 
 jobs:
   automerge:
-    if: >-
-      contains(join(github.event.pull_request.labels.*.name, ','), 'automerge') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Автослияние PR


### PR DESCRIPTION
## Резюме
- запускаем workflow автомёрджа при создании PR
- убираем требование метки `automerge`, оставляя ограничение на репозиторий-источник

## Влияние на производительность и сеть
- без изменений

## Модули
- `.github/workflows/automerge-codex.yml`

## Ретраи и обработка ошибок
- логика не менялась

------
https://chatgpt.com/codex/tasks/task_e_68d9264c2a388330a294f49fae5b2e9a