### PR TITLE
fix: обработка конфликта 409 в клиенте Telegram

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-telegram-bot==20.7
 
 black==24.8.0
 ruff==0.6.5
+pytest==8.3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Общие настройки для тестов."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT_DIR / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -1,0 +1,45 @@
+"""Тесты для клиента Telegram."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from telegram_post.telegram_client import TelegramClient
+
+
+def test_fetch_new_messages_handles_conflict(monkeypatch, caplog):
+    """Метод должен игнорировать 409 Conflict и возвращать пустой результат."""
+
+    async def run_test() -> None:
+        client = TelegramClient(
+            "test-token",
+            source_user_id=123,
+            target_channel="@target",
+            max_attempts=1,
+        )
+
+        request = httpx.Request(
+            "GET", f"{client.base_url}/bot{client.token}/getUpdates"
+        )
+        response = httpx.Response(status_code=409, request=request)
+        error = httpx.HTTPStatusError("Conflict", request=request, response=response)
+
+        async def fake_get(*args, **kwargs):
+            raise error
+
+        monkeypatch.setattr(client._client, "get", fake_get)
+
+        with caplog.at_level("WARNING"):
+            messages, new_last_update = await client.fetch_new_messages(
+                last_update_id=42
+            )
+
+        await client.aclose()
+
+        assert messages == []
+        assert new_last_update == 42
+        assert any("409" in record.getMessage() for record in caplog.records)
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Описание
- добавлена обработка ответа Telegram Bot API со статусом 409 при получении обновлений
- реализован модульный тест, эмулирующий конфликт и проверяющий отсутствие исключения
- настроен общий conftest для src-структуры и добавлен pytest в зависимости

## Влияние на производительность и сеть
- без изменений: дополнительная ветка обработки ошибки не влияет на сетевые запросы

## Затронутые модули
- `src/telegram_post/telegram_client.py`
- `tests/conftest.py`
- `tests/test_telegram_client.py`
- `requirements.txt`

## Логика ретраев и обработка ошибок
- при завершении ретраев с последней причиной `HTTPStatusError` 409 клиент логирует предупреждение и возвращает пустой результат вместо исключения

------
https://chatgpt.com/codex/tasks/task_e_68d9309e2bf083309a1bd7457b88704f