### PR TITLE
fix: расширить определение отправителя в TelegramClient

### DIFF
--- a/src/telegram_post/telegram_client.py
+++ b/src/telegram_post/telegram_client.py
@@ -140,8 +140,24 @@ class TelegramClient:
             message_block = update.get("channel_post") or update.get("message") or {}
             sender_chat = message_block.get("sender_chat") or {}
             from_user = message_block.get("from") or {}
-            sender_id = sender_chat.get("id") or from_user.get("id")
-            if sender_id != self.source_user_id:
+            sender_id_raw_candidates = (
+                sender_chat.get("id"),
+                from_user.get("id"),
+                (message_block.get("chat") or {}).get("id"),
+            )
+            sender_id: Optional[int] = None
+            for sender_id_raw in sender_id_raw_candidates:
+                if sender_id_raw is None:
+                    continue
+                try:
+                    sender_id = int(sender_id_raw)
+                except (TypeError, ValueError):
+                    sender_id = None
+                    continue
+                else:
+                    break
+
+            if sender_id is None or sender_id != self.source_user_id:
                 continue
 
             text = message_block.get("text") or message_block.get("caption")


### PR DESCRIPTION
## Цель изменения
- добавить резервный источник идентификатора отправителя для сообщений Telegram и безопасно сравнивать его с `source_user_id`
- подтвердить корректную обработку `channel_post` без `sender_chat` через модульный тест

## Влияние на производительность и сеть
- изменений в количестве запросов или таймаутах нет

## Затронутые модули
- `src/telegram_post/telegram_client.py`
- `tests/test_telegram_client.py`

## Обработка ошибок и ретраи
- существующие механизмы `tenacity` для повторов запросов к Bot API не изменялись

------
https://chatgpt.com/codex/tasks/task_e_68d93ffbf8dc8330b41ae37206870ed7