### PR TITLE
fix: обновить конфигурацию канала Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 | `DEEPSEEK_APPI`          | API-ключ DeepSeek                           |
 | `USERNAMETELERGRAMBOT`   | Юзернейм бота (например, `@my_bot`)         |
 | `TELEGRAMKEY`            | Токен Telegram Bot API                      |
-| `TELEGRAMKANAL`          | ID/юзернейм канала для публикации постов    |
+| `TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE` | ID/юзернейм канала для публикации постов (можно использовать `TELEGRAMKANAL` для обратной совместимости) |
 | `TGUSERID`               | ID канала-источника (значение `sender_chat`)|
 
 Создайте файл `.env` или экспортируйте переменные в окружение перед запуском.

--- a/src/telegram_post/config.py
+++ b/src/telegram_post/config.py
@@ -39,14 +39,31 @@ class Settings:
 
         env_mapping = env or os.environ
         required = {
-            "deepseek_api_key": "DEEPSEEK_APPI",
-            "telegram_bot_username": "USERNAMETELERGRAMBOT",
-            "telegram_bot_token": "TELEGRAMKEY",
-            "telegram_target_channel": "TELEGRAMKANAL",
-            "telegram_source_user_id": "TGUSERID",
+            "deepseek_api_key": ("DEEPSEEK_APPI",),
+            "telegram_bot_username": ("USERNAMETELERGRAMBOT",),
+            "telegram_bot_token": ("TELEGRAMKEY",),
+            "telegram_target_channel": (
+                "TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE",
+                "TELEGRAMKANAL",
+            ),
+            "telegram_source_user_id": ("TGUSERID",),
         }
 
-        missing = [var for var in required.values() if not env_mapping.get(var)]
+        resolved: dict[str, str] = {}
+        missing: list[str] = []
+
+        for field, names in required.items():
+            for name in names:
+                value = env_mapping.get(name)
+                if value:
+                    resolved[field] = value
+                    break
+            else:
+                formatted = " или ".join(names)
+                if len(names) > 1:
+                    formatted += " (укажите хотя бы одну переменную)"
+                missing.append(formatted)
+
         if missing:
             raise SettingsError(
                 "Отсутствуют обязательные переменные окружения: "
@@ -54,14 +71,14 @@ class Settings:
             )
 
         try:
-            source_user_id = int(env_mapping[required["telegram_source_user_id"]])
+            source_user_id = int(resolved["telegram_source_user_id"])
         except ValueError as exc:  # pragma: no cover - защита от некорректного ввода
             raise SettingsError("TGUSERID должен быть целым числом") from exc
 
         return cls(
-            deepseek_api_key=env_mapping[required["deepseek_api_key"]],
-            telegram_bot_username=env_mapping[required["telegram_bot_username"]],
-            telegram_bot_token=env_mapping[required["telegram_bot_token"]],
-            telegram_target_channel=env_mapping[required["telegram_target_channel"]],
+            deepseek_api_key=resolved["deepseek_api_key"],
+            telegram_bot_username=resolved["telegram_bot_username"],
+            telegram_bot_token=resolved["telegram_bot_token"],
+            telegram_target_channel=resolved["telegram_target_channel"],
             telegram_source_user_id=source_user_id,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+"""Тесты для загрузки настроек из окружения."""
+
+from __future__ import annotations
+
+import pytest
+
+from telegram_post.config import Settings, SettingsError
+
+
+@pytest.fixture()
+def base_env() -> dict[str, str]:
+    """Базовый набор переменных окружения для валидных настроек."""
+
+    return {
+        "DEEPSEEK_APPI": "deepseek",
+        "USERNAMETELERGRAMBOT": "@bot",
+        "TELEGRAMKEY": "token",
+        "TGUSERID": "123",
+        "TELEGRAMKANAL": "@legacy-channel",
+    }
+
+
+def test_settings_prefers_new_channel_variable(base_env: dict[str, str]) -> None:
+    """Новая переменная канала имеет приоритет над устаревшей."""
+
+    base_env.pop("TELEGRAMKANAL", None)
+    base_env["TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE"] = "@new-channel"
+
+    settings = Settings.from_env(base_env)
+
+    assert settings.telegram_target_channel == "@new-channel"
+
+
+def test_settings_falls_back_to_legacy_variable(base_env: dict[str, str]) -> None:
+    """При отсутствии новой переменной используется старое имя."""
+
+    base_env.pop("TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE", None)
+
+    settings = Settings.from_env(base_env)
+
+    assert settings.telegram_target_channel == "@legacy-channel"
+
+
+def test_settings_error_when_both_channel_variables_missing(
+    base_env: dict[str, str]
+) -> None:
+    """Сообщение об ошибке поясняет необходимость указать одну из переменных."""
+
+    base_env.pop("TELEGRAMKANAL", None)
+    base_env.pop("TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE", None)
+
+    with pytest.raises(SettingsError) as exc_info:
+        Settings.from_env(base_env)
+
+    message = str(exc_info.value)
+    assert "TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE" in message
+    assert "TELEGRAMKANAL" in message
+    assert "укажите хотя бы одну" in message


### PR DESCRIPTION
## Summary
- добавить приоритет чтения `TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE` и понятное сообщение об отсутствии переменных
- обновить таблицу переменных окружения в README и покрыть сценарии новым тестом

## Testing
- pytest -q

## Impact
- влияние на производительность и сеть: отсутствует, логика загрузки конфигурации не выполняет сетевых запросов
- затронутые модули: src/telegram_post/config.py, tests/test_config.py, README.md
- обработка ошибок и ретраи: улучшена диагностика отсутствующих переменных окружения для канала


------
https://chatgpt.com/codex/tasks/task_e_68d94803e898833087ec62ea082da5a6