### PR TITLE
fix: обновить переменные окружения источника Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 | `USERNAMETELERGRAMBOT`   | Юзернейм бота (например, `@my_bot`)         |
 | `TELEGRAMKEY`            | Токен Telegram Bot API                      |
 | `TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE` | ID/юзернейм канала для публикации постов (можно использовать `TELEGRAMKANAL` для обратной совместимости) |
-| `TGUSERID`               | ID канала-источника (значение `sender_chat`)|
+| `TG_ISTO4NIK_ID`         | ID канала-источника (значение `sender_chat`, поддерживается `TGUSERID` как устаревшее имя) |
 
 Создайте файл `.env` или экспортируйте переменные в окружение перед запуском.
 

--- a/src/telegram_post/config.py
+++ b/src/telegram_post/config.py
@@ -46,7 +46,7 @@ class Settings:
                 "TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE",
                 "TELEGRAMKANAL",
             ),
-            "telegram_source_user_id": ("TGUSERID",),
+            "telegram_source_user_id": ("TG_ISTO4NIK_ID", "TGUSERID"),
         }
 
         resolved: dict[str, str] = {}
@@ -73,7 +73,9 @@ class Settings:
         try:
             source_user_id = int(resolved["telegram_source_user_id"])
         except ValueError as exc:  # pragma: no cover - защита от некорректного ввода
-            raise SettingsError("TGUSERID должен быть целым числом") from exc
+            raise SettingsError(
+                "TG_ISTO4NIK_ID (или TGUSERID) должен быть целым числом"
+            ) from exc
 
         return cls(
             deepseek_api_key=resolved["deepseek_api_key"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ def base_env() -> dict[str, str]:
         "DEEPSEEK_APPI": "deepseek",
         "USERNAMETELERGRAMBOT": "@bot",
         "TELEGRAMKEY": "token",
+        "TG_ISTO4NIK_ID": "123",
         "TGUSERID": "123",
         "TELEGRAMKANAL": "@legacy-channel",
     }
@@ -39,6 +40,30 @@ def test_settings_falls_back_to_legacy_variable(base_env: dict[str, str]) -> Non
     settings = Settings.from_env(base_env)
 
     assert settings.telegram_target_channel == "@legacy-channel"
+
+
+def test_settings_prefers_new_source_user_variable(base_env: dict[str, str]) -> None:
+    """Для ID источника приоритет у новой переменной окружения."""
+
+    base_env["TG_ISTO4NIK_ID"] = "456"
+    base_env["TGUSERID"] = "789"
+
+    settings = Settings.from_env(base_env)
+
+    assert settings.telegram_source_user_id == 456
+
+
+def test_settings_falls_back_to_legacy_source_user_variable(
+    base_env: dict[str, str]
+) -> None:
+    """Если новой переменной нет, используется устаревшее имя."""
+
+    base_env.pop("TG_ISTO4NIK_ID", None)
+    base_env["TGUSERID"] = "654"
+
+    settings = Settings.from_env(base_env)
+
+    assert settings.telegram_source_user_id == 654
 
 
 def test_settings_error_when_both_channel_variables_missing(


### PR DESCRIPTION
## Цель
- отдать приоритет переменной `TG_ISTO4NIK_ID` для идентификатора канала-источника и сохранить поддержку `TGUSERID` как запасного варианта

## Влияние на производительность и сеть
- отсутствует

## Затронутые модули
- `src/telegram_post/config.py`
- `tests/test_config.py`
- `README.md`

## Ретраи и обработка ошибок
- обновлено сообщение об ошибке валидации, механика ретраев не менялась

------
https://chatgpt.com/codex/tasks/task_e_68d95491b0d083308260d287ab431e27