### PR TITLE
fix: ограничить обновления в Telegram-клиенте

### DIFF
--- a/src/telegram_post/telegram_client.py
+++ b/src/telegram_post/telegram_client.py
@@ -79,7 +79,14 @@ class TelegramClient:
             Список сообщений и новый ``last_update_id``.
         """
 
-        params: dict[str, Any] = {"timeout": 0}
+        params: dict[str, Any] = {
+            "timeout": 0,
+            "allowed_updates": [
+                "message",
+                "channel_post",
+                "edited_channel_post",
+            ],
+        }
         if last_update_id is not None:
             params["offset"] = last_update_id + 1
 


### PR DESCRIPTION
## Цель изменения
- ограничить типы обновлений, которые клиент Telegram запрашивает у Bot API

## Влияние на производительность и сеть
- запросы `getUpdates` теперь получают только сообщения и посты каналов, что сокращает объём ненужных данных

## Затронутые модули
- `src/telegram_post/telegram_client.py`
- `tests/test_telegram_client.py`

## Обработка ошибок и ретраи
- существующая логика ретраев и обработки 409 сохранена без изменений

## Тестирование
- `ruff check`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d95a1e9f7083309336b536ff73c8f5