### PR TITLE
fix: корректно выбирать источник окружения

### DIFF
--- a/src/telegram_post/config.py
+++ b/src/telegram_post/config.py
@@ -37,7 +37,7 @@ class Settings:
             Экземпляр настроек.
         """
 
-        env_mapping = env or os.environ
+        env_mapping = os.environ if env is None else env
         required = {
             "deepseek_api_key": ("DEEPSEEK_APPI",),
             "telegram_bot_username": ("USERNAMETELERGRAMBOT",),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,13 @@ def test_settings_falls_back_to_legacy_variable(base_env: dict[str, str]) -> Non
     assert settings.telegram_target_channel == "@legacy-channel"
 
 
+def test_settings_requires_environment_variables() -> None:
+    """При отсутствии всех переменных конфигурации выбрасывается ошибка."""
+
+    with pytest.raises(SettingsError):
+        Settings.from_env({})
+
+
 def test_settings_prefers_new_source_user_variable(base_env: dict[str, str]) -> None:
     """Для ID источника приоритет у новой переменной окружения."""
 


### PR DESCRIPTION
## Цель
- Исправить выбор источника переменных окружения для `Settings`.
- Обеспечить генерацию ошибки при пустом окружении.

## Влияние на производительность и сеть
- Не влияет на производительность и сетевые обращения.

## Затронутые модули
- `src/telegram_post/config.py`
- `tests/test_config.py`

## Обработка ошибок и ретраи
- Добавлена явная проверка на отсутствие обязательных переменных, дополнительных ретраев не требуется.

## Тесты
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d962ef790483308c451bd3be02f070