### PR TITLE
fix(telegram-client): сериализовать список allowed_updates

### DIFF
--- a/src/telegram_post/telegram_client.py
+++ b/src/telegram_post/telegram_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any, Iterable, List, Optional, Tuple
@@ -79,13 +80,14 @@ class TelegramClient:
             Список сообщений и новый ``last_update_id``.
         """
 
+        allowed_updates = [
+            "message",
+            "channel_post",
+            "edited_channel_post",
+        ]
         params: dict[str, Any] = {
             "timeout": 0,
-            "allowed_updates": [
-                "message",
-                "channel_post",
-                "edited_channel_post",
-            ],
+            "allowed_updates": json.dumps(allowed_updates),
         }
         if last_update_id is not None:
             params["offset"] = last_update_id + 1

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 
+import json
+
 import httpx
 import pytest
 
@@ -101,13 +103,16 @@ def test_fetch_new_messages_passes_allowed_updates(monkeypatch):
 
         async def fake_get(*args, **kwargs):
             params = kwargs.get("params") or {}
-            assert params == {
-                "timeout": 0,
-                "allowed_updates": [
-                    "message",
-                    "channel_post",
-                    "edited_channel_post",
-                ],
+            assert set(params.keys()) == {"timeout", "allowed_updates"}
+            assert params["timeout"] == 0
+
+            allowed_updates_raw = params["allowed_updates"]
+            assert isinstance(allowed_updates_raw, str)
+            allowed_updates = json.loads(allowed_updates_raw)
+            assert set(allowed_updates) == {
+                "message",
+                "channel_post",
+                "edited_channel_post",
             }
             return success_response
 


### PR DESCRIPTION
## Цель изменения
* Сериализовать список `allowed_updates` в `TelegramClient.fetch_new_messages`, чтобы соответствовать ожиданиям Telegram Bot API.
* Обновить покрывающий тест на проверку корректности сериализации.

## Влияние на производительность и сеть
* Изменений в количестве или длительности сетевых запросов нет.

## Затронутые модули
* `src/telegram_post/telegram_client.py`
* `tests/test_telegram_client.py`

## Логика ретраев и обработка ошибок
* Поведение ретраев не менялось.

## Тесты
* `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d965a994c88330aa46e912eab2878a