### PR TITLE
feat: маскировка секретов в логах конфигурации

### DIFF
--- a/src/telegram_post/config.py
+++ b/src/telegram_post/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from dataclasses import fields
 from typing import Mapping, MutableMapping
 
 
@@ -20,6 +21,25 @@ class Settings:
     telegram_bot_token: str
     telegram_target_channel: str
     telegram_source_user_id: int
+
+    @staticmethod
+    def mask_secret(value: str) -> str:
+        """Скрыть середину секретного значения."""
+
+        if not value:
+            return value
+        prefix = value[:2]
+        suffix = value[-2:]
+        return f"{prefix}***{suffix}"
+
+    def masked_secrets(self) -> dict[str, str]:
+        """Получить маскированные значения конфигурации."""
+
+        masked: dict[str, str] = {}
+        for field in fields(self):
+            value = getattr(self, field.name)
+            masked[field.name] = self.mask_secret(str(value))
+        return masked
 
     @classmethod
     def from_env(

--- a/src/telegram_post/main.py
+++ b/src/telegram_post/main.py
@@ -161,6 +161,11 @@ def run_poll_once(state_file: Path = DEFAULT_STATE_FILE) -> None:
         typer.echo(str(exc))
         raise typer.Exit(code=1) from exc
 
+    masked_pairs = ", ".join(
+        f"{name}={value}" for name, value in settings.masked_secrets().items()
+    )
+    logger.info("Загружены переменные: %s", masked_pairs)
+
     last_update_id = read_last_update_id(state_file)
     new_last_update = asyncio.run(poll_once(settings, last_update_id=last_update_id))
     if new_last_update is not None:
@@ -175,6 +180,11 @@ def run_poll_loop(interval: int = 60) -> None:
     except SettingsError as exc:  # pragma: no cover
         typer.echo(str(exc))
         raise typer.Exit(code=1) from exc
+
+    masked_pairs = ", ".join(
+        f"{name}={value}" for name, value in settings.masked_secrets().items()
+    )
+    logger.info("Загружены переменные: %s", masked_pairs)
 
     asyncio.run(poll_loop(settings, interval=interval))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
+from telegram_post import main
 from telegram_post.config import Settings, SettingsError
 
 
@@ -88,3 +91,46 @@ def test_settings_error_when_both_channel_variables_missing(
     assert "TELEGRAMKANAL_ID_S_MINYSOM_V_NA4ALE" in message
     assert "TELEGRAMKANAL" in message
     assert "укажите хотя бы одну" in message
+
+
+def test_mask_secret_masks_middle() -> None:
+    """Маскирование скрывает середину строки."""
+
+    assert Settings.mask_secret("abcdef") == "ab***ef"
+
+
+def test_run_poll_once_logs_masked_settings(tmp_path, monkeypatch, caplog) -> None:
+    """При запуске CLI логируются маскированные настройки."""
+
+    settings = Settings(
+        deepseek_api_key="deepseekkey",
+        telegram_bot_username="@botusername",
+        telegram_bot_token="tokenvalue",
+        telegram_target_channel="@channelname",
+        telegram_source_user_id=123456,
+    )
+
+    monkeypatch.setattr(
+        main.Settings,
+        "from_env",
+        classmethod(lambda cls: settings),
+    )
+    monkeypatch.setattr(main, "read_last_update_id", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main, "write_last_update_id", lambda *_args, **_kwargs: None)
+    def _fake_asyncio_run(coro, *_args, **_kwargs):
+        coro.close()
+        return None
+
+    monkeypatch.setattr(main.asyncio, "run", _fake_asyncio_run)
+
+    caplog.set_level(logging.INFO, logger=main.logger.name)
+
+    main.run_poll_once(state_file=tmp_path / "state.json")
+
+    expected_pairs = ", ".join(
+        f"{name}={value}" for name, value in settings.masked_secrets().items()
+    )
+    expected_message = f"Загружены переменные: {expected_pairs}"
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert expected_message in messages


### PR DESCRIPTION
## Цель
- скрыть значения чувствительных переменных при выводе конфигурации и проверить формат логов

## Влияние на производительность и сеть
- отсутствует

## Изменения
- добавлена утилита маскирования секретов в `Settings` и предоставлен словарь маскированных значений
- расширены CLI-обёртки логированием маскированных параметров
- добавлены проверки маскировки и формата логов в тестах конфигурации

## Логика ретраев / обработка ошибок
- без изменений

## Тесты
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d965b2335c833086b692b1ea707240